### PR TITLE
new md to dom implementation based on mistletoe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "requests",
-        "beautifulsoup4",
-        "Markdown",
+        "mistletoe",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Hi, I started to use this library for this tiny bot I'm developing: [readeckbot](https://github.com/mgaitan/readeckbot)

I realized that for non-trivial markdown content, the original `md_to_dom` function produces incorrect nested nodes, omitting the separations.

![image](https://github.com/user-attachments/assets/52b255c2-3439-4cf8-b6a8-ebc0a31e1cc4)

So I decided to fix this using a different approach. Instead of rendering as HTML and then "scraping" it, I simply use a markdown parser, [mistletoe](https://github.com/miyuchina/mistletoe), and get the output by defining a custom renderer.

The result is more correct and also faster:

- [Test Original Parser](https://telegra.ph/test-original-parser-03-15)
- [Test New Parser](https://telegra.ph/test-new-parser-03-15)

![image](https://github.com/user-attachments/assets/ae67520e-47c2-4db7-a51f-b0abbd5607dc)


I have a notebook with details [here](https://gist.github.com/mgaitan/03974a60b834ad673e5166d8d1ac5279)
